### PR TITLE
Cleanup tmp directory when running as a nagios check

### DIFF
--- a/ipa_check_consistency
+++ b/ipa_check_consistency
@@ -674,6 +674,7 @@ nagios_check() {
   fi
   msg="${msg} - ${oks}/${CHECKS_NO} checks passed"
 	printf "%s\n" "$msg"
+  cleanup
   exit $code
 }
 


### PR DESCRIPTION
Bugfix - when run with the nagios option the tmp directory wasn't being cleaned up which could result in a large number of tmp dirs. This cleans it up before exiting.