### PR TITLE
Search for forward DNS zones too

### DIFF
--- a/ipa_check_consistency
+++ b/ipa_check_consistency
@@ -544,7 +544,8 @@ dns_zones() {
   for server in "${SERVERS[@]}"; do
     (
     if ! count=$(query_ldap "cn=dns,${SUFFIX}" \
-      "(objectClass=idnszone)" "dn" "one"); then
+      "(|(objectClass=idnszone)(objectClass=idnsforwardzone))" \
+      "dn" "one"); then
       count="ERROR"
     else
       count=$(grep -c "^dn:" <<<"$count" || true)


### PR DESCRIPTION
FreeIPA support both master and forward zones, so both should be
included in search output


Untested