### PR TITLE
Create a base class for counter plugins

### DIFF
--- a/ipa_consistency_checker/plugins/counters.py
+++ b/ipa_consistency_checker/plugins/counters.py
@@ -161,3 +161,13 @@ class SUDORules(Counter):
     container = 'cn=sudorules,cn=sudo'
     ldapfilter = '(ipaUniqueID=*)'
     count_entries = True
+
+
+@CheckerRegistry.register('zones', description='DNS zones')
+class DNSZones(Counter):
+    """
+    Count number of DNS zones
+    """
+    container = 'cn=dns'
+    ldapfilter = '(|(objectClass=idnszone)(objectClass=idnsforwardzone))'
+    count_entries = True

--- a/ipa_consistency_checker/plugins/counters.py
+++ b/ipa_consistency_checker/plugins/counters.py
@@ -151,3 +151,13 @@ class HBACRules(Counter):
     container = 'cn=hbac'
     ldapfilter = '(ipaUniqueID=*)'
     count_entries = True
+
+
+@CheckerRegistry.register('sudo', description='SUDO rules')
+class SUDORules(Counter):
+    """
+    Count number of SUDO rules
+    """
+    container = 'cn=sudorules,cn=sudo'
+    ldapfilter = '(ipaUniqueID=*)'
+    count_entries = True

--- a/ipa_consistency_checker/plugins/counters.py
+++ b/ipa_consistency_checker/plugins/counters.py
@@ -101,3 +101,11 @@ class Hosts(Counter):
     Count number of hosts
     """
     container = 'cn=computers,cn=accounts'
+
+
+@CheckerRegistry.register('hgroups', description='Host groups')
+class HostGroups(Counter):
+    """
+    Count number of host groups
+    """
+    container = 'cn=hostgroups,cn=accounts'

--- a/ipa_consistency_checker/plugins/counters.py
+++ b/ipa_consistency_checker/plugins/counters.py
@@ -141,3 +141,13 @@ class HostGroups(Counter):
     Count number of host groups
     """
     container = 'cn=hostgroups,cn=accounts'
+
+
+@CheckerRegistry.register('hbac', description='HBAC rules')
+class HBACRules(Counter):
+    """
+    Count number of HBAC rules
+    """
+    container = 'cn=hbac'
+    ldapfilter = '(ipaUniqueID=*)'
+    count_entries = True

--- a/ipa_consistency_checker/plugins/counters.py
+++ b/ipa_consistency_checker/plugins/counters.py
@@ -117,6 +117,16 @@ class PreservedUsers(Counter):
     container = 'cn=deleted users,cn=accounts,cn=provisioning'
 
 
+@CheckerRegistry.register('ugroups', description='User groups')
+class UserGroups(Counter):
+    """
+    Count number of user groups
+    """
+    container = 'cn=groups,cn=accounts'
+    ldapfilter = '(objectClass=ipausergroup)'
+    count_entries = True
+
+
 @CheckerRegistry.register('hosts', description='Hosts')
 class Hosts(Counter):
     """

--- a/ipa_consistency_checker/plugins/counters.py
+++ b/ipa_consistency_checker/plugins/counters.py
@@ -87,6 +87,14 @@ class StageUsers(Counter):
     container = 'cn=staged users,cn=accounts,cn=provisioning'
 
 
+@CheckerRegistry.register('upres', description='Preserved users')
+class PreservedUsers(Counter):
+    """
+    Count number of preserved users
+    """
+    container = 'cn=deleted users,cn=accounts,cn=provisioning'
+
+
 @CheckerRegistry.register('hosts', description='Hosts')
 class Hosts(Counter):
     """

--- a/ipa_consistency_checker/plugins/counters.py
+++ b/ipa_consistency_checker/plugins/counters.py
@@ -79,6 +79,14 @@ class ActiveUsers(Counter):
     container = 'cn=users,cn=accounts'
 
 
+@CheckerRegistry.register('ustage', description='Stage users')
+class StageUsers(Counter):
+    """
+    Count number of stage users
+    """
+    container = 'cn=staged users,cn=accounts,cn=provisioning'
+
+
 @CheckerRegistry.register('hosts', description='Hosts')
 class Hosts(Counter):
     """


### PR DESCRIPTION
Subclases of Counter must specify only 'container' and 'ldapfilter' all
other functionality has been implemented in base class. This makes
easier to create a new checkers.