### PR TITLE
set rpm requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,21 +18,23 @@ classifiers =
     Programming Language :: Python :: 3.6
     License :: OSI Approved :: GNU General Public License v3 (GPLv3)
     Topic :: System :: Systems Administration :: Authentication/Directory :: LDAP
+
+    
+[options]
+include_package_data = True
+packages = checkipaconsistency
 install_requires =
     pyldap>=2.4.15
     prettytable>=0.7.2
     dnspython>=1.12.0
     
-[options]
-include_package_data = True
-packages = checkipaconsistency
-
 [bdist_rpm]
 requires = 
     python-ldap >= 2.4.15
     python-prettytable >= 0.7.2
     python-dns >= 1.12.0
-release = 5
+install_requires = 
+release = 6
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ classifiers =
     License :: OSI Approved :: GNU General Public License v3 (GPLv3)
     Topic :: System :: Systems Administration :: Authentication/Directory :: LDAP
 
-    
 [options]
 include_package_data = True
 packages = checkipaconsistency

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ classifiers =
 include_package_data = True
 packages = checkipaconsistency
 install_requires =
-    pyldap>=2.4.15
+    python-ldap>=2.4.15
     prettytable>=0.7.2
     dnspython>=1.12.0
     

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ requires =
     python-ldap >= 2.4.15
     python-prettytable >= 0.7.2
     python-dns >= 1.12.0
-release = 6
+release = 2
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,6 @@ requires =
     python-ldap >= 2.4.15
     python-prettytable >= 0.7.2
     python-dns >= 1.12.0
-install_requires = 
 release = 6
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,21 +18,21 @@ classifiers =
     Programming Language :: Python :: 3.6
     License :: OSI Approved :: GNU General Public License v3 (GPLv3)
     Topic :: System :: Systems Administration :: Authentication/Directory :: LDAP
-
+install_requires =
+    pyldap>=2.4.15
+    prettytable>=0.7.2
+    dnspython>=1.12.0
+    
 [options]
 include_package_data = True
 packages = checkipaconsistency
-install_requires =
-    pyldap>=2.4.45
-    prettytable>=0.7.2
-    dnspython>=1.15.0
-    
+
 [bdist_rpm]
 requires = 
-    python-ldap >= 2.4.45
+    python-ldap >= 2.4.15
     python-prettytable >= 0.7.2
     python-dns >= 1.12.0
-release = 2
+release = 5
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,13 @@ install_requires =
     pyldap>=2.4.45
     prettytable>=0.7.2
     dnspython>=1.15.0
+    
+[bdist_rpm]
+requires = 
+    python-ldap >= 2.4.45
+    python-prettytable >= 0.7.2
+    python-dns >= 1.12.0
+release = 2
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,6 @@ requires =
     python-ldap >= 2.4.15
     python-prettytable >= 0.7.2
     python-dns >= 1.12.0
-release = 2
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
python setup.py bdist_rpm needs these requirements to create an rpm with the correct dependencies.

Changes proposed in this pull request:
- set correct bdist_rpm requirements
- bump rpm release so we don't need to bump version but get a working rpm if a broken one was previously created
- lower pyldap and python-dns required versions to match the versions shipped by Centos/RedHat 7.4 (and used by freeipa)

@peterpakos
